### PR TITLE
The `skip_tables` option is now a list of regular expressions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
   "rust-analyzer.checkOnSave.command": "clippy",
   "todo-tree.regex.regex": "((//|#|<!--|;|/\\*|^)\\s*($TAGS)|($TAGS)!.*)",
-  "todo-tree.regex.regexCaseSensitive": false
+  "todo-tree.regex.regexCaseSensitive": false,
+  "cSpell.words": [
+    "indicatif",
+    "inputfile",
+    "itertools"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ schema_name = "public"
 database_url = "postgres://localhost:15432/postgres"
 features = ["currency", "audit"]
 skip_tables = [
-  "users_backup"
-  # ... a list of regular expressions.
+  "_backup&"
+  "^obsolete_"
+  # ... more regular expressions
 ]
 
 [overrides]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ database_url = "postgres://localhost:15432/postgres"
 features = ["currency", "audit"]
 skip_tables = [
   "users_backup"
+  # ... a list of regular expressions.
 ]
 
 [overrides]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use lazy_static::lazy_static;
 use postgres::Client;
 use regex::{Regex, RegexSet};
 use sql_string::SqlString;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::io::Write;
 use std::path::Path;


### PR DESCRIPTION
This allows for skipping, say, all tables with a certain prefix.